### PR TITLE
Support version 2.7, custom templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ Follow the Elastifile Cloud Deployment GCP Installation Guide to make sure ECFS 
 ## Use:
 1. Create password.txt file with a password to use for eManage  (.gitignore skips this file)
 2. Specify configuration variables in terraform.tfvars:
+- TEMPLATE_TYPE = small, medium, standard, custom
 - NUM_OF_VMS = Number of ECFS virtual controllers, 3 minimum
-- DISKTYPE = "persistent" or "local"
-- NUM_OF_DISKS = Number of disks per virtual controller. 1-5 for local SSD, 1-10 for persistent SSD
+- DISK_TYPE = local, ssd, or hdd. Only applies to custom templates
+- DISK_CONFIG = [disks per vm]_[disk size in GB] example: "8_375" will create 8, 375GB disks. Only applies to custom templates
+- VM_CONFIG = [cpu cores per vm]_[ram per vm] example "20_128" will create 20 CPU, 128GB RAM VMs. Default: "4_42" Only applies to custom templates
 - CLUSTER_NAME = Name for ECFS service
 - ZONE = Zone
 - PROJECT = Project name
@@ -20,6 +22,7 @@ Follow the Elastifile Cloud Deployment GCP Installation Guide to make sure ECFS 
 - CREDENTIALS = path to service account credentials .json file
 - SERVICE_EMAIL = service account email address
 3. Run 'terraform init' then 'terraform apply'
+
 
 ## Components:
 

--- a/create_vheads.sh
+++ b/create_vheads.sh
@@ -81,7 +81,7 @@ curl -k -D $SESSION_FILE -H "Content-Type: application/json" -X POST -d '{"user"
 }
 
 function first_run {
-  #wait for EMS to complete loading after instance creation
+  #loop function to wait for EMS to complete loading after instance creation
   while true; do
     emsresponse=`curl -k -s -D $SESSION_FILE -H "Content-Type: application/json" -X POST -d '{"user": {"login":"admin","password":"changeme"}}' https://$EMS_ADDRESS/api/sessions | grep created_at | cut -d , -f 8 | cut -d \" -f 2`
     echo -e "Waiting for EMS init...\n" | tee -a $LOG
@@ -122,8 +122,8 @@ function set_storage_type_custom {
     cpu_cores=`echo $3 | cut -d "_" -f 1`
     ram=`echo $3 | cut -d "_" -f 2`
     echo -e "Setting custom storage type: $type, num of disks: $disks, disk size=$disk_size cpu cores: $cpu_cores, ram: $ram \n" | tee -a $LOG
-    curl -k -b $SESSION_FILE -H "Content-Type: application/json" -X POST -d '{"name":"custom","storage_type":"'$type'","num_of_disks":'$disks',"disk_size":'$disk_size',"instance_type":"custom","cores":'$cpu_cores',"memory":'$ram',"min_num_of_instances":3}' https://$EMS_ADDRESS/api/cloud_configurations
-    curl -k -b $SESSION_FILE -H "Content-Type: application/json" -X PUT -d '{"id":1,"load_balancer_use":true,"cloud_configuration_id":5}' https://$EMS_ADDRESS/api/cloud_providers/1
+    curl -k -b $SESSION_FILE -H "Content-Type: application/json" -X POST -d '{"name":"custom","storage_type":"'$type'","num_of_disks":'$disks',"disk_size":'$disk_size',"instance_type":"custom","cores":'$cpu_cores',"memory":'$ram',"min_num_of_instances":3}' https://$EMS_ADDRESS/api/cloud_configurations >> $LOG 2>&1
+    curl -k -b $SESSION_FILE -H "Content-Type: application/json" -X PUT -d '{"id":1,"load_balancer_use":true,"cloud_configuration_id":5}' https://$EMS_ADDRESS/api/cloud_providers/1 >> $LOG 2>&1
 }
 
 function setup_ems {

--- a/google_ecfs.tf
+++ b/google_ecfs.tf
@@ -74,6 +74,7 @@ resource "google_compute_instance" "Elastifile-ECFS" {
     ecfs_ems = "true"
     reference_name = "${var.CLUSTER_NAME}"
     version = "${var.IMAGE}"
+    template_type = "${var.TEMPLATE_TYPE}"
     disk_type = "${var.DISK_TYPE}"
     disk_config = "${var.DISK_CONFIG}"
     password_is_changed = "${var.PASSWORD_IS_CHANGED}"

--- a/google_ecfs.tf
+++ b/google_ecfs.tf
@@ -1,11 +1,17 @@
-variable "DISKTYPE"{
-  default = "local"
+variable "DISK_TYPE"{
+  default = "persistent"
+}
+variable "TEMPLATE_TYPE"{
+  default = "medium"
+}
+variable "VM_CONFIG"{
+  default = "4_42"
 }
 variable "NUM_OF_VMS"{
   default = "3"
 }
-variable "NUM_OF_DISKS"{
-  default = "1"
+variable "DISK_CONFIG"{
+  default = "5_2000"
 }
 variable "CLUSTER_NAME"{
 }
@@ -68,8 +74,8 @@ resource "google_compute_instance" "Elastifile-ECFS" {
     ecfs_ems = "true"
     reference_name = "${var.CLUSTER_NAME}"
     version = "${var.IMAGE}"
-    disk_type = "${var.DISKTYPE}"
-    num_disks = "${var.NUM_OF_DISKS}"
+    disk_type = "${var.DISK_TYPE}"
+    disk_config = "${var.DISK_CONFIG}"
     password_is_changed = "${var.PASSWORD_IS_CHANGED}"
     setup_complete = "${var.SETUP_COMPLETE}"
   }
@@ -86,7 +92,7 @@ resource "google_compute_instance" "Elastifile-ECFS" {
 
 resource "null_resource" "create_cluster" {
   provisioner "local-exec" {
-    command = "./create_vheads.sh -t ${var.DISKTYPE} -n ${var.NUM_OF_VMS} -m ${var.NUM_OF_DISKS}"
+    command = "./create_vheads.sh -c ${var.TEMPLATE_TYPE} -t ${var.DISK_TYPE} -n ${var.NUM_OF_VMS} -d ${var.DISK_CONFIG} -v ${var.VM_CONFIG}"
     interpreter = ["/bin/bash","-c"]
 
   }

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -1,10 +1,10 @@
-TEMPLATE_TYPE = "custom"
+TEMPLATE_TYPE = "medium"
 #small,medium,standard,custom
 DISK_TYPE = "local"
 #local,ssd,hdd
 VM_CONFIG = "20_128"
 # <cpucores>_<ram> default: 4_42
-NUM_OF_VMS = "3"
+NUM_OF_VMS = "0"
 DISK_CONFIG = "8_375"
 # <num_of_disks>_<disk_size>
 MIN_CLUSTER = "4"
@@ -13,6 +13,6 @@ ZONE = "us-west1-c"
 PROJECT = "elastifile-sa"
 NETWORK = "default"
 SUBNETWORK = "default"
-IMAGE = "emanage-2-7-0-10-b730e81f3597"
+IMAGE = "emanage-2-7-0-13-60091bce109e"
 CREDENTIALS = "andrew-sa-elastifile-sa.json"
 SERVICE_EMAIL = "andrew-sa@elastifile-sa.iam.gserviceaccount.com"

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -1,11 +1,18 @@
-NUM_OF_VMS = "8"
-DISKTYPE = "local"
-NUM_OF_DISKS = "8"
+TEMPLATE_TYPE = "custom"
+#small,medium,standard,custom
+DISK_TYPE = "local"
+#local,ssd,hdd
+VM_CONFIG = "20_128"
+# <cpucores>_<ram> default: 4_42
+NUM_OF_VMS = "3"
+DISK_CONFIG = "8_375"
+# <num_of_disks>_<disk_size>
+MIN_CLUSTER = "4"
 CLUSTER_NAME = "ecfs"
 ZONE = "us-west1-c"
 PROJECT = "elastifile-sa"
 NETWORK = "default"
 SUBNETWORK = "default"
-IMAGE = "emanage-2-5-2-3-dae80938c27a"
+IMAGE = "emanage-2-7-0-10-b730e81f3597"
 CREDENTIALS = "andrew-sa-elastifile-sa.json"
 SERVICE_EMAIL = "andrew-sa@elastifile-sa.iam.gserviceaccount.com"

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -4,7 +4,7 @@ DISK_TYPE = "local"
 #local,ssd,hdd
 VM_CONFIG = "20_128"
 # <cpucores>_<ram> default: 4_42
-NUM_OF_VMS = "0"
+NUM_OF_VMS = "3"
 DISK_CONFIG = "8_375"
 # <num_of_disks>_<disk_size>
 MIN_CLUSTER = "4"


### PR DESCRIPTION
Changes to support ECFS version 2.7:

- Selecting number of VMs=0 deploys only the EMS instance for completing configuration via web GUI
- Built in template selection (small, medium, pd-standard)
- Create custom templates (number of cpu cores, ram, disk type, number of disks)
- Loop to verify EMS services availability before configuring
